### PR TITLE
Join group/Leave group reloading/navigation fixed 

### DIFF
--- a/frontend/src/components/singleGroupPage/SingleGroupPage.js
+++ b/frontend/src/components/singleGroupPage/SingleGroupPage.js
@@ -78,6 +78,7 @@ const SingleGroupPage = ({ navigate }) => {
 				method: 'post',
 				headers: {'Authorization': `Bearer ${token}`}
 			})
+			window.location.reload();
 			}
 		
 			const handleLeaveGroup = () =>  {
@@ -87,6 +88,7 @@ const SingleGroupPage = ({ navigate }) => {
 					method: 'post',
 					headers: {'Authorization': `Bearer ${token}`}
 				})
+				navigate(`/groups`)
 				}
 
 
@@ -108,9 +110,6 @@ const SingleGroupPage = ({ navigate }) => {
 								Join Group
 						</button>
 						)}
-						{hasJoinedGroup && (
-							<h1 id='group-joined'>You've joined this group</h1> 
-							)}
 					</div>
 
 					{/* LEAVE BUTTON - members*/}
@@ -120,11 +119,8 @@ const SingleGroupPage = ({ navigate }) => {
 									Leave Group
 							</button>
 							)}
-							{hasLeftGroup && (
-								<h1 id='group-joined'>You've left this group</h1> 
-								)}
 					</div>
-							<h1 id='pub-group-name' className='group-page-main-title'>Group members</h1>
+							<h2 id='pub-group-name' className='group-page-main-title'>Group members</h2>
 					<div className='members-list'>
         {members && members.length > 0 ? (
           <div id="member-name" className='member-name'>
@@ -145,7 +141,7 @@ const SingleGroupPage = ({ navigate }) => {
 					<div id='members-only-section'>
 
 					<div className='list-of-ongoing-wagers'>
-						<h2>ongoing wagers in the group go here:</h2>
+						<h2 id='ongoing-wagers'> Ongoing wagers</h2>
             <ul>
               {ongoingGroupWagers.map((wager) => (
 								<li id='ongoing-wager' key={wager._id}>
@@ -157,7 +153,7 @@ const SingleGroupPage = ({ navigate }) => {
 					</div>
 
 					<div className='list-of-wins-losses'>
-					<h2>recent wins and losses go here - Boozers and Losers</h2>
+					<h2 id='wins-and-losses'>Wins and losses</h2>
             <ul>
 						{resolvedGroupWagers.map((wager) => (
 							<li id='resolved-wager' key={wager._id}>
@@ -174,7 +170,6 @@ const SingleGroupPage = ({ navigate }) => {
 						))}
 						</ul>
           </div>
-						recent wins and losses go here
 				</div>
 				) : (
 


### PR DESCRIPTION
What's up, friend and team-mate. Clicking Leave group button now takes user to Groups page and clicking Join group button now reloads Single Group page revealing all relevant group info